### PR TITLE
Bug Fix: Wrong number of shoes shown

### DIFF
--- a/src/main/java/com/example/auctionapp/model/Category.java
+++ b/src/main/java/com/example/auctionapp/model/Category.java
@@ -31,7 +31,7 @@ public class Category {
     )
     private List<Category> subcategories;
 
-    @Formula(value="(SELECT COUNT(i.id) FROM item i WHERE i.subcategory_id=id)")
+    @Formula(value="(SELECT COUNT(i.id) FROM item i WHERE i.subcategory_id=id AND i.end_date > now())")
     private int noOfItems;
 
     public Long getId() {


### PR DESCRIPTION
The issue was that the formula which was calculating the amount of items in each category did not take into account whether the item's auction has passed. Considering that such items are not displayed to the user, the bug occurred since there are 4 shoes in total in the application, but one of them is not an active item anymore. Now the formula takes into account that the item's auction period has not ended and displays correct information.