### PR TITLE
Bug Fix: Time left 

### DIFF
--- a/src/main/frontend/src/utils/Utils.js
+++ b/src/main/frontend/src/utils/Utils.js
@@ -12,8 +12,8 @@ export const calculateTimeLeft = (endDate) => {
     if (hours < 24) {
         return Math.round(hours) + " hours";
     } else if (hours >= 24 && hours < 168) {
-        return Math.round(hours/24) + " days " + Math.round(hours%24) + " hours" ;
+        return Math.floor(hours/24) + " days " + Math.round(hours%24) + " hours" ;
     } else {
-        return Math.round(hours/168) + " weeks " + Math.round((hours%168)/24) + " days";
+        return Math.floor(hours/168) + " weeks " + Math.round((hours%168)/24) + " days";
     }
 };


### PR DESCRIPTION
When items are sorted by time left, they are in fact sorted by their end date, which is stored in the database. This sorting functions as intended and is in accordance with the end date values, but the issue is in the calculation of time left for the auction. Within the part of code that compares the end date and current date, the function that was used is Math.round(), which rounds up to the nearest number, while actually floor division was required, so now the Math.floor() function is used, which discards the remainder during division, as intended. 