### PR TITLE
Bug Fix: Names should not contain special characters

### DIFF
--- a/src/main/frontend/src/components/loginAndRegistration/RegisterForm.js
+++ b/src/main/frontend/src/components/loginAndRegistration/RegisterForm.js
@@ -80,7 +80,7 @@ function RegisterForm() {
           name="name"
           value={name}
           onChange={onChangeName}
-          validations={[Validations.required]}
+          validations={[Validations.required, Validations.validName]}
         />
       </div>
       <div className={styles.formSection}>
@@ -91,7 +91,7 @@ function RegisterForm() {
           name="surname"
           value={surname}
           onChange={onChangeSurname}
-          validations={[Validations.required]}
+          validations={[Validations.required, Validations.validName]}
         />
       </div>
       <div className={styles.formSection}>

--- a/src/main/frontend/src/utils/Validations.js
+++ b/src/main/frontend/src/utils/Validations.js
@@ -30,8 +30,21 @@ const validPassword = (value) => {
   }
 };
 
+const validName = (value) => {
+  const validateName = /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]+/;
+  const isNameInvalid = validateName.test(value.toString());
+  if (isNameInvalid) {
+    return (
+      <div className="alert alert-danger" role="alert">
+        Names cannot contain any special characters.
+     </div>
+    );
+  }
+};
+
 export default {
   required,
   validEmail,
-  validPassword
+  validPassword,
+  validName
 };

--- a/src/main/frontend/src/utils/Validations.js
+++ b/src/main/frontend/src/utils/Validations.js
@@ -31,9 +31,8 @@ const validPassword = (value) => {
 };
 
 const validName = (value) => {
-  const validateName = /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]+/;
-  const isNameInvalid = validateName.test(value.toString());
-  if (isNameInvalid) {
+  const validateName = new RegExp("^[\\w\\sčšđćž]+$");
+  if (!validateName.test(value)) {
     return (
       <div className="alert alert-danger" role="alert">
         Names cannot contain any special characters.


### PR DESCRIPTION
First name and last name fields, which are a part of the registration form, did not have any content validation - meaning that if any characters are entered the registration would have been successful. Now using regular expressions, a validation is added to verify that they cannot contain any special characters. 